### PR TITLE
Improve app performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "base-64": "^0.1.0",
     "firebase": "^4.6.0",
     "localStorage": "^1.0.3",
+    "preact": "^8.2.6",
+    "preact-compat": "^3.17.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "smoothscroll-polyfill": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     "firebase": "^4.6.0",
     "isomorphic-fetch": "^2.2.1",
     "localStorage": "^1.0.3",
-    "node-sass-chokidar": "^0.0.3",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "smoothscroll-polyfill": "^0.4.0"
   },
   "devDependencies": {
-    "react-scripts": "1.0.7"
+    "react-scripts": "1.0.7",
+    "node-sass-chokidar": "^0.0.3"
   },
   "scripts": {
     "build-css": "node-sass-chokidar src/App.scss -o src/",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "dependencies": {
     "base-64": "^0.1.0",
     "firebase": "^4.6.0",
-    "isomorphic-fetch": "^2.2.1",
     "localStorage": "^1.0.3",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
-    "smoothscroll-polyfill": "^0.4.0"
+    "smoothscroll-polyfill": "^0.4.0",
+    "unfetch": "^3.0.0"
   },
   "devDependencies": {
     "react-scripts": "1.0.7",

--- a/src/api/fetch-wrapper.js
+++ b/src/api/fetch-wrapper.js
@@ -1,4 +1,5 @@
-import 'isomorphic-fetch';
+// import 'isomorphic-fetch';
+import fetch from 'unfetch';
 
 export const get = requestOptions => {
   let statusCode;

--- a/src/components/async-component-loader/index.js
+++ b/src/components/async-component-loader/index.js
@@ -1,0 +1,39 @@
+import React, { PureComponent } from 'react';
+
+export default class AsyncComponentLoader extends PureComponent {
+    constructor(props) {
+        super(props);
+        this.state = {
+            Component: null
+        };
+        this.loadComponent = this.loadComponent.bind(this);
+    }
+
+    loadComponent({ componentName, loadComponentModule }) {
+        console.error(new Date(), 'Loading componentName', componentName);
+        loadComponentModule()
+            .then(({ default: Component }) => {
+                console.error(new Date(), 'Loaded componentName', componentName);
+                this.setState(() => ({ Component }));
+            }).catch(console.error);
+    }
+
+    componentWillMount() {
+    	const { componentName, loadComponentModule } = this.props;
+        this.loadComponent({ componentName, loadComponentModule });
+    }
+
+    componentWillReceiveProps({ componentName, loadComponentModule }) {
+        console.error('AsyncComponentLoader componentWillReceiveProps');
+        this.loadComponent({ componentName, loadComponentModule });
+    }
+
+    render() {
+        const { Component } = this.state;
+        if (!Component) {
+            return null;
+        }
+        const { componentProps } = this.props;
+        return <Component {...componentProps} />;
+    }
+}

--- a/src/components/competition/index.js
+++ b/src/components/competition/index.js
@@ -2,16 +2,32 @@ import React from 'react';
 
 import DataLayer from '../../data';
 
-import PlaceholderCompetition from '../placeholder-competition';
-import Teams from '../teams';
-import Fixtures from '../fixtures';
-import LeagueTable from '../league-table';
-import ChampionsLeagueTable from '../champions-league-table';
-import CompetitionCard from '../competition-card';
-import CompetitionScrollableTabs from '../competition-scrollable-tabs';
+// import PlaceholderCompetition from '../placeholder-competition';
+// import Fixtures from '../fixtures';
+// import Teams from '../teams';
+// import LeagueTable from '../league-table';
+// import ChampionsLeagueTable from '../champions-league-table';
+
+// import CompetitionCard from '../competition-card';
+// import CompetitionScrollableTabs from '../competition-scrollable-tabs';
+import AsyncComponentLoader from '../async-component-loader';
 
 import Cache from '../../utils/cache';
 import mixpanel from '../../utils/mixpanel';
+
+const PlaceholderCompetition = () =>
+    import(/* webpackChunkName: "placeholder-competition" */'../placeholder-competition');
+const CompetitionCard = () =>
+    import(/* webpackChunkName: "competition-card" */'../competition-card');
+const CompetitionScrollableTabs = () =>
+    import(/* webpackChunkName: "competition-scrollable-tabs" */'../competition-scrollable-tabs');
+const Fixtures = () =>
+    import(/* webpackChunkName: "fixtures" */'../fixtures');
+const LeagueTable = () =>
+    import(/* webpackChunkName: "league-table" */'../league-table');
+const ChampionsLeagueTable = () =>
+    import(/* webpackChunkName: "champions-league-table" */'../champions-league-table');
+const Teams = () => import(/* webpackChunkName: "teams" */'../teams');
 
 const CompetitionError = () => (
   <div className="fa-competition-error-container">
@@ -23,13 +39,34 @@ const CompetitionError = () => (
 
 const CompetitionData = ({ caption, name, id, selected: { name: selectedName } }) => {
   if (selectedName === 'Fixtures') {
-    return <Fixtures name={name} id={id} />;
+    return (
+      <AsyncComponentLoader
+        loadComponentModule={Fixtures}
+        componentProps={{name, id}}
+        componentName="Fixtures"
+      />
+    );
+    // return <Fixtures name={name} id={id} />;
   }
   if (selectedName === 'Teams') {
-    return <Teams name={name} id={id} />;
+    return (
+      <AsyncComponentLoader
+        loadComponentModule={Teams}
+        componentProps={{name, id}}
+        componentName="Teams"
+      />
+    );
+    // return <Teams name={name} id={id} />;
   }
   const Table = caption.indexOf('Champions League') !== -1 ? ChampionsLeagueTable : LeagueTable;
-  return <Table name={name} id={id} />;
+  return (
+    <AsyncComponentLoader
+      loadComponentModule={Table}
+      componentProps={{name, id}}
+      componentName="Table"
+    />
+  );
+  // return <Table name={name} id={id} />;
 };
 
 class Competition extends React.Component {
@@ -100,7 +137,13 @@ class Competition extends React.Component {
   render() {
     const { loading, competition, competitionData, selected } = this.state;
     if (loading) {
-      return <PlaceholderCompetition />;
+      // return <PlaceholderCompetition />;
+      return (
+        <AsyncComponentLoader
+          loadComponentModule={PlaceholderCompetition}
+          componentName="PlaceholderCompetition"
+        />
+      );
     }
 
     const {
@@ -115,16 +158,39 @@ class Competition extends React.Component {
 
     const { name, id } = this.props;
 
+    // return (
+    //   <div className="fa-competition-container">
+    //     <CompetitionScrollableTabs
+    //       competitionData={competitionData}
+    //       selected={selected}
+    //       selectCompetitionData={name => this.selectCompetitionData(name)}
+    //     />
+    //     <CompetitionCard
+    //       currentMatchday={currentMatchday}
+    //       numberOfMatchdays={numberOfMatchdays}
+    //     />
+    //     <div className="fa-competition-data">
+    //       <CompetitionData
+    //         caption={caption}
+    //         name={name}
+    //         id={id}
+    //         selected={selected}
+    //       />
+    //     </div>
+    //   </div>
+    // );
+
     return (
       <div className="fa-competition-container">
-        <CompetitionScrollableTabs
-          competitionData={competitionData}
-          selected={selected}
-          selectCompetitionData={name => this.selectCompetitionData(name)}
+        <AsyncComponentLoader
+          loadComponentModule={CompetitionScrollableTabs}
+          componentProps={{competitionData, selected, selectCompetitionData: name => this.selectCompetitionData(name)}}
+          componentName="CompetitionScrollableTabs"
         />
-        <CompetitionCard
-          currentMatchday={currentMatchday}
-          numberOfMatchdays={numberOfMatchdays}
+        <AsyncComponentLoader
+          loadComponentModule={CompetitionCard}
+          componentProps={{currentMatchday, numberOfMatchdays}}
+          componentName="CompetitionCard"
         />
         <div className="fa-competition-data">
           <CompetitionData

--- a/src/components/competitions/index.js
+++ b/src/components/competitions/index.js
@@ -2,15 +2,22 @@ import React from 'react';
 
 import DataLayer from '../../data';
 
-import Competition from '../competition';
-import CompetitionsScrollableTabs from '../competitions-scrollable-tabs';
+// import Competition from '../competition';
+// import CompetitionsScrollableTabs from '../competitions-scrollable-tabs';
 
 import leagueLabels from '../../data/league-labels';
 import leagueRankings from '../../data/league-rankings';
 import Cache from '../../utils/cache';
 import mixpanel from '../../utils/mixpanel';
 import smoothScrollPolyfill from '../../utils/smooth-scroll';
+import AsyncComponentLoader from '../async-component-loader';
 smoothScrollPolyfill();
+
+
+const CompetitionsScrollableTabs = () =>
+	import(/* webpackChunkName: "competitions-scrollable-tabs" */'../competitions-scrollable-tabs');
+const Competition = () =>
+	import(/* webpackChunkName: "competition" */'../competition');
 
 const CompetitionsError = () => (
   <div className="fa-competitions-container">
@@ -89,15 +96,32 @@ class Competitions extends React.Component {
       return <CompetitionsError />;
     }
 
+    // return (
+    //   <div className="fa-competitions-container">
+    //     <CompetitionsScrollableTabs
+    //       competitions={competitions}
+    //       selected={selected}
+    //       selectCompetition={this._selectCompetition}
+    //     />
+    //     <div className="fa-competitions-data">
+    //       <Competition {...selected} />
+    //     </div>
+    //   </div>
+    // );
+
     return (
       <div className="fa-competitions-container">
-        <CompetitionsScrollableTabs
-          competitions={competitions}
-          selected={selected}
-          selectCompetition={this._selectCompetition}
+      	<AsyncComponentLoader
+          loadComponentModule={CompetitionsScrollableTabs}
+          componentProps={{competitions, selected, selectCompetition: this._selectCompetition}}
+          componentName="CompetitionsScrollableTabs"
         />
         <div className="fa-competitions-data">
-          <Competition {...selected} />
+          <AsyncComponentLoader
+            loadComponentModule={Competition}
+            componentProps={{...selected}}
+            componentName="Competition"
+          />
         </div>
       </div>
     );

--- a/src/components/day-fixtures/index.js
+++ b/src/components/day-fixtures/index.js
@@ -1,31 +1,72 @@
 import React from 'react';
 
-import Fixture from '../fixture';
-import FixtureMatchWeek from '../fixture-match-week';
+// import Fixture from '../fixture';
+// import FixtureMatchWeek from '../fixture-match-week';
+import AsyncComponentLoader from '../async-component-loader';
+
+const Fixture = () =>
+    import(/* webpackChunkName: "fixture" */'../fixture');
+const FixtureMatchWeek = () =>
+    import(/* webpackChunkName: "fixture-match-week" */'../fixture-match-week');
 
 const DayFixtures = ({ fixtureDay, fixtures, team, timeFrame }) => {
   const filteredFixtures = team ? fixtures.filter(({
       awayTeamName, homeTeamName
     }) => awayTeamName === team || homeTeamName === team
   ) : fixtures;
+
+  // return (
+  //   <div className="fa-day-fixtures-container">
+  //     <FixtureMatchWeek number={fixtureDay} />
+  //     <div className="fa-day-fixtures">
+  //       {
+  //         filteredFixtures.map((fixture, index) => {
+  //           const { _links: { self: { href: fixtureLink } } } = fixture;
+  //           const fixtureLinkParts = fixtureLink.split("/");
+  //           const fixtureID = Number(fixtureLinkParts[fixtureLinkParts.length - 1]);
+  //           return (
+  //             <Fixture
+  //               {...fixture}
+  //               key={ index }
+  //               timeFrame={timeFrame}
+  //               fixtureID={fixtureID}
+  //               source="DayFixtures"
+  //             />
+  //           );
+  //         })
+  //       }
+  //     </div>
+  //   </div>
+  // );
   return (
     <div className="fa-day-fixtures-container">
-      <FixtureMatchWeek number={fixtureDay} />
+      <AsyncComponentLoader
+        loadComponentModule={FixtureMatchWeek}
+        componentProps={{number: fixtureDay}}
+        componentName="FixtureMatchWeek"
+      />
       <div className="fa-day-fixtures">
         {
           filteredFixtures.map((fixture, index) => {
             const { _links: { self: { href: fixtureLink } } } = fixture;
             const fixtureLinkParts = fixtureLink.split("/");
             const fixtureID = Number(fixtureLinkParts[fixtureLinkParts.length - 1]);
+            // return (
+            //   <Fixture
+            //     {...fixture}
+            //     key={ index }
+            //     timeFrame={timeFrame}
+            //     fixtureID={fixtureID}
+            //     source="DayFixtures"
+            //   />
+            // );
             return (
-              <Fixture
-                {...fixture}
-                key={ index }
-                timeFrame={timeFrame}
-                fixtureID={fixtureID}
-                source="DayFixtures"
-              />
-            );
+              <AsyncComponentLoader
+         		loadComponentModule={Fixture}
+         		componentProps={{timeFrame, fixtureID, source: "DayFixtures", ...fixture}}
+         		componentName="Fixture"
+      		  />
+        	);
           })
         }
       </div>

--- a/src/components/day-fixtures/index.js
+++ b/src/components/day-fixtures/index.js
@@ -62,6 +62,7 @@ const DayFixtures = ({ fixtureDay, fixtures, team, timeFrame }) => {
             // );
             return (
               <AsyncComponentLoader
+                key={ index }
          		loadComponentModule={Fixture}
          		componentProps={{timeFrame, fixtureID, source: "DayFixtures", ...fixture}}
          		componentName="Fixture"

--- a/src/components/fixture/index.js
+++ b/src/components/fixture/index.js
@@ -1,9 +1,21 @@
 import React from 'react';
 
-import FixtureDate from '../fixture-date';
-import FixtureResult from '../fixture-result';
-import FixtureTeams from '../fixture-teams';
-import FixtureSubscription from '../fixture-subscription';
+// import FixtureDate from '../fixture-date';
+// import FixtureResult from '../fixture-result';
+// import FixtureTeams from '../fixture-teams';
+// import FixtureSubscription from '../fixture-subscription';
+
+import AsyncComponentLoader from '../async-component-loader';
+
+const FixtureDate = () =>
+    import(/* webpackChunkName: "fixture-date" */'../fixture-date');
+const FixtureResult = () =>
+    import(/* webpackChunkName: "fixture-result" */'../fixture-result');
+const FixtureTeams = () =>
+    import(/* webpackChunkName: "fixture-teams" */'../fixture-teams');
+const FixtureSubscription = () =>
+    import(/* webpackChunkName: "fixture-subscription" */'../fixture-subscription');
+
 
 const Dummy = () => <div />;
 
@@ -21,17 +33,41 @@ const Fixture = ({
   const className = isGameLive ? 'fa-fixture-container-live' : 'fa-fixture-container';
   const showNotificationsToggle = isGameLive === false && status !== 'FINISHED';
   const NotificationToggle = showNotificationsToggle ? FixtureSubscription : Dummy;
+  // return (
+  //   <div className={className}>
+  //     <NotificationToggle
+  //       fixtureID={fixtureID}
+  //       date={date}
+  //       homeTeamName={homeTeamName}
+  //       awayTeamName={awayTeamName}
+  //     />
+  //     <FixtureTeams homeTeam={homeTeamName} awayTeam={awayTeamName} />
+  //     <FixtureResult {...result} timeDifferenceInMins={timeDifferenceInMins} />
+  //     <FixtureDate date={date} status={status} />
+  //   </div>
+  // );
   return (
     <div className={className}>
-      <NotificationToggle
-        fixtureID={fixtureID}
-        date={date}
-        homeTeamName={homeTeamName}
-        awayTeamName={awayTeamName}
+      <AsyncComponentLoader
+        loadComponentModule={NotificationToggle}
+        componentProps={{fixtureID, date, homeTeamName, awayTeamName}}
+        componentName="NotificationToggle"
       />
-      <FixtureTeams homeTeam={homeTeamName} awayTeam={awayTeamName} />
-      <FixtureResult {...result} timeDifferenceInMins={timeDifferenceInMins} />
-      <FixtureDate date={date} status={status} />
+      <AsyncComponentLoader
+        loadComponentModule={FixtureTeams}
+        componentProps={{homeTeam: homeTeamName, awayTeam: awayTeamName}}
+        componentName="FixtureTeams"
+      />
+      <AsyncComponentLoader
+        loadComponentModule={FixtureResult}
+        componentProps={{timeDifferenceInMins, ...result}}
+        componentName="FixtureResult"
+      />
+      <AsyncComponentLoader
+        loadComponentModule={FixtureDate}
+        componentProps={{date, status}}
+        componentName="FixtureDate"
+      />
     </div>
   );
 };

--- a/src/components/fixtures/index.js
+++ b/src/components/fixtures/index.js
@@ -2,12 +2,17 @@ import React from 'react';
 
 import DataLayer from '../../data';
 
-import DayFixtures from '../day-fixtures';
+// import DayFixtures from '../day-fixtures';
 
 import Cache from '../../utils/cache';
 import mixpanel from '../../utils/mixpanel';
 
-import PlaceholderFixtures from '../placeholder-fixtures';
+// import PlaceholderFixtures from '../placeholder-fixtures';
+import AsyncComponentLoader from '../async-component-loader';
+const PlaceholderFixtures = () =>
+    import(/* webpackChunkName: "placeholder-fixtures" */'../placeholder-fixtures');
+const DayFixtures = () =>
+    import(/* webpackChunkName: "day-fixtures" */'../day-fixtures');
 
 const FixturesListError = () => (
   <div className="fa-fixtures-error">
@@ -24,13 +29,20 @@ const FixturesList = ({ fixtures, timeFrame, team, dayFixtures }) => {
       {
         Object.keys(fixtures).map(fixtureDay => {
           const dayFixtures = fixtures[fixtureDay];
+          // return (
+          //   <DayFixtures
+          //     key={fixtureDay}
+          //     timeFrame={timeFrame}
+          //     team={team}
+          //     fixtureDay={fixtureDay}
+          //     fixtures={dayFixtures}
+          //   />
+          // );
           return (
-            <DayFixtures
-              key={fixtureDay}
-              timeFrame={timeFrame}
-              team={team}
-              fixtureDay={fixtureDay}
-              fixtures={dayFixtures}
+            <AsyncComponentLoader
+              loadComponentModule={DayFixtures}
+              componentProps={{key: fixtureDay, timeFrame, team, fixtureDay, fixtures: dayFixtures}}
+              componentName="DayFixtures"
             />
           );
         })
@@ -263,7 +275,13 @@ class Fixtures extends React.Component {
     } = this.state;
 
     if (loading) {
-      return <PlaceholderFixtures />;
+      // return <PlaceholderFixtures />;
+      return (
+        <AsyncComponentLoader
+          loadComponentModule={PlaceholderFixtures}
+          componentName="PlaceholderFixtures"
+        />
+      );
     }
 
     const fixtures = timeFrame.indexOf('n') === -1 ? oldFixtures : upcomingFixtures;

--- a/src/components/fixtures/index.js
+++ b/src/components/fixtures/index.js
@@ -40,6 +40,7 @@ const FixturesList = ({ fixtures, timeFrame, team, dayFixtures }) => {
           // );
           return (
             <AsyncComponentLoader
+              key={fixtureDay}
               loadComponentModule={DayFixtures}
               componentProps={{key: fixtureDay, timeFrame, team, fixtureDay, fixtures: dayFixtures}}
               componentName="DayFixtures"
@@ -321,7 +322,6 @@ class Fixtures extends React.Component {
           fixtures={fixtures}
           timeFrame={timeFrame}
           team={team}
-          dayFixtures
         />
       </div>
     );

--- a/src/components/onboarding/index.js
+++ b/src/components/onboarding/index.js
@@ -6,11 +6,16 @@ import {
 } from '../../utils/onboarding';
 import DataLayer from '../../data';
 
-import Competitions from '../competitions';
+// import Competitions from '../competitions';
 
 import Cache from '../../utils/cache';
 import fetchIPInformation from '../../utils/ip';
 import mixpanel from '../../utils/mixpanel';
+
+import AsyncComponentLoader from '../async-component-loader';
+
+const Competitions = () =>
+	import(/* webpackChunkName: 'competitions' */'../competitions');
 
 class Onboarding extends React.Component {
   constructor() {
@@ -45,7 +50,13 @@ class Onboarding extends React.Component {
   render() {
     const { onboardingShown } = this.state;
     if (onboardingShown) {
-      return <Competitions />;
+      // return <Competitions />;
+      return (
+	    <AsyncComponentLoader
+	      loadComponentModule={Competitions}
+	      componentName="Competitions"
+	    />
+	  );
     }
 
     return (

--- a/src/data/competitions.js
+++ b/src/data/competitions.js
@@ -13,13 +13,13 @@ const fetchCompetitions = () => {
       if (isDevelopment) {
         console.log('response (cache)', response);
       }
-      _fetchCompetitions()
-        .then(apiResponse => Cache.set(Cache.keys.COMPETITIONS, apiResponse))
-        .catch(error => {
-          if (isDevelopment) {
-            console.log('error (api)', error);
-          }
-        });
+      // _fetchCompetitions()
+      //   .then(apiResponse => Cache.set(Cache.keys.COMPETITIONS, apiResponse))
+      //   .catch(error => {
+      //     if (isDevelopment) {
+      //       console.log('error (api)', error);
+      //     }
+      //   });
       return response;
     }).catch(error => {
       if (isDevelopment) {

--- a/src/data/league-table.js
+++ b/src/data/league-table.js
@@ -9,41 +9,42 @@ const fetchCompetitionLeagueTable = (competitionID, filterParam) => {
     console.log('Data layer fetchCompetitionFixtures');
   }
   const cacheKey = `LEAGUE_TABLE-${competitionID}-${filterParam}`;
-  return _fetchCompetitionLeagueTable(competitionID, filterParam)
-    .then(apiResponse => {
-      if (isDevelopment) {
-        console.log('api response', apiResponse);
+  return Cache.get(cacheKey)
+    .then(({apiResponse, updatedAt}) => {
+      const currentTime = new Date();
+      if (((currentTime - new Date(updatedAt)) / 1000) < 900) {
+        return apiResponse;
       }
-      Cache.set(cacheKey, apiResponse)
-        .catch(error => {
-          if (isDevelopment) {
-            console.log('error (Cache.set)', error);
-          }
-        });
-      return apiResponse;
-    }).catch(error => {
-      if (isDevelopment) {
-        console.log('error (_fetchFixture())', error);
-      }
-      return Cache
-        .get(cacheKey)
-        .then(response => {
-          if (isDevelopment) {
-            console.log('response (cache)', response);
-          }
-          _fetchCompetitionLeagueTable(competitionID, filterParam)
-            .then(apiResponse => Cache.set(cacheKey, apiResponse))
+      return _fetchCompetitionLeagueTable(competitionID, filterParam)
+        .then(apiResponse => {
+          const cacheData = {
+            apiResponse,
+            updatedAt: (new Date()).getTime()
+          };
+          Cache
+            .set(cacheKey, cacheData)
             .catch(error => {
               if (isDevelopment) {
-                console.log('error (api)', error);
+                console.log('error (Cache.set)', error);
               }
             });
-          return response;
-        }).catch(error => {
-          if (isDevelopment) {
-            console.log('error (cache)', error);
-          }
-          return Promise.reject(error);
+          return apiResponse
+        });
+    }).catch(error => {
+      return _fetchCompetitionLeagueTable(competitionID, filterParam)
+        .then(apiResponse => {
+          const cacheData = {
+            apiResponse,
+            updatedAt: (new Date()).getTime()
+          };
+          Cache
+            .set(cacheKey, cacheData)
+            .catch(error => {
+              if (isDevelopment) {
+                console.log('error (Cache.set)', error);
+              }
+            });
+          return apiResponse
         });
     });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2966,6 +2966,12 @@ ignore@^3.2.0:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
 
+immutability-helper@^2.1.2:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/immutability-helper/-/immutability-helper-2.5.0.tgz#01ea7204334997c645bdfa7eb22e8b84c970946e"
+  dependencies:
+    invariant "^2.2.0"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -4801,6 +4807,30 @@ postcss@^6.0.1, postcss@^6.x:
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
+preact-compat@^3.17.0:
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/preact-compat/-/preact-compat-3.17.0.tgz#528cfdfc301190c1a0f47567336be1f4be0266b3"
+  dependencies:
+    immutability-helper "^2.1.2"
+    preact-render-to-string "^3.6.0"
+    preact-transition-group "^1.1.0"
+    prop-types "^15.5.8"
+    standalone-react-addons-pure-render-mixin "^0.1.1"
+
+preact-render-to-string@^3.6.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-3.7.0.tgz#7db4177454bc01395e0d01d6ac07bc5e838e31ee"
+  dependencies:
+    pretty-format "^3.5.1"
+
+preact-transition-group@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/preact-transition-group/-/preact-transition-group-1.1.1.tgz#f0a49327ea515ece34ea2be864c4a7d29e5d6e10"
+
+preact@^8.2.6:
+  version "8.2.6"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.2.6.tgz#0028b426ef98fcca741a3c617ff5b813b9a947c7"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -4831,6 +4861,10 @@ pretty-format@^20.0.3:
     ansi-regex "^2.1.1"
     ansi-styles "^3.0.0"
 
+pretty-format@^3.5.1:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
+
 private@^0.1.6:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
@@ -4857,7 +4891,7 @@ promise@7.1.1, promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10:
+prop-types@^15.5.10, prop-types@^15.5.8:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -5649,6 +5683,10 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+standalone-react-addons-pure-render-mixin@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/standalone-react-addons-pure-render-mixin/-/standalone-react-addons-pure-render-mixin-0.1.1.tgz#3c7409f4c79c40de9ac72c616cf679a994f37551"
+
 "statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
@@ -5973,6 +6011,10 @@ uglify-to-browserify@~1.0.0:
 uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
+
+unfetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-3.0.0.tgz#8d1e0513a4ecd0e5ff2d41a6ba77771aae8b6482"
 
 uniq@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
There are 3 ways of improving app performance - 

- [x] Lazy load components so that main bundle is small
- [x] Replacing `react` with `preact` to reduce bundle size (using webpack's `resolve.alias`)
- [x] Move from surge.sh to github-pages as rendering times are smaller
- [x] Takes cache first approach for fetching data